### PR TITLE
add container for Rocky Linux 8.6

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -19,6 +19,7 @@ jobs:
           - opensuse-15.3
           - opensuse-15.4
           - rockylinux-8.5
+          - rockylinux-8.6
           - almalinux-8.6
           - almalinux-9.0
           - ubuntu-20.04
@@ -88,6 +89,7 @@ jobs:
           - opensuse-15.3
           - opensuse-15.4
           - rockylinux-8.5
+          - rockylinux-8.6
           - almalinux-8.6
           - almalinux-9.0
           - ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Containers for testing EasyBuild, built automatically for `x86_64` and `aarch64`
 * `opensuse-15.3`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/opensuse-15.3/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/opensuse-15.3)
 * `opensuse-15.4`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/opensuse-15.4/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/opensuse-15.4)
 * `rockylinux-8.5`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/rockylinux-8.5/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/rockylinux-8.5)
+* `rockylinux-8.6`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/rockylinux-8.6/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/rockylinux-8.6)
 * `ubuntu-20.04`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/ubuntu-20.04/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/ubuntu-20.04)
 * `ubuntu-22.04`: [recipe](https://github.com/easybuilders/easybuild-containers/blob/main/ubuntu-22.04/Dockerfile), [image @ ghcr.io](https://github.com/easybuilders/easybuild-containers/pkgs/container/ubuntu-22.04)
 

--- a/rockylinux-8.6/Dockerfile
+++ b/rockylinux-8.6/Dockerfile
@@ -1,0 +1,8 @@
+FROM rockylinux/rockylinux:8.6.20220515
+RUN useradd -ms /bin/bash easybuild
+# enable PowerTools repository, required by Lmod in EPEL
+RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
+&& dnf -y install epel-release && dnf -y install python3 Lmod
+# glibc-langpack-en provides locale stuff (for en_US.UTF-8)
+RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN python3 -m pip install archspec


### PR DESCRIPTION
Unfortunately there is no tag `rockylinux:8.6` yet, that is why I am using the tag `rockylinux:8.6.20220515`.