### PR TITLE
update container for Rocky Linux 8.6

### DIFF
--- a/rockylinux-8.6/Dockerfile
+++ b/rockylinux-8.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:8.6.20220515
+FROM rockylinux/rockylinux:8.6
 RUN useradd -ms /bin/bash easybuild
 # enable PowerTools repository, required by Lmod in EPEL
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \

--- a/rockylinux-8.6/Dockerfile
+++ b/rockylinux-8.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:8.6
+FROM rockylinux:8.6
 RUN useradd -ms /bin/bash easybuild
 # enable PowerTools repository, required by Lmod in EPEL
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \


### PR DESCRIPTION
Since the tag `rockylinux:8.6` was added recently, we can use it now.