### PR TITLE
Fix container for almalinux 9.0 and centosstream 9

### DIFF
--- a/almalinux-9.0/Dockerfile
+++ b/almalinux-9.0/Dockerfile
@@ -5,7 +5,8 @@ RUN dnf -y update \
 # enable crb repository
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
-RUN dnf -y install bzip2 curl-minimal diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+# --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
+RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source

--- a/centosstream-9/Dockerfile
+++ b/centosstream-9/Dockerfile
@@ -5,10 +5,13 @@ RUN dnf -y update \
 # enable crb repository
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
-RUN dnf -y install bzip2 curl-minimal diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+# --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
+RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source
+# gcc-c++ has dependency on environment-modules, but we want to use Lmod
+# Therefore we need to remove /etc/profile.d/modules.{sh,csh}
 RUN curl -LO https://sourceforge.net/projects/lmod/files/Lmod-${LMOD_VER}.tar.bz2 \
  && tar xf Lmod-${LMOD_VER}.tar.bz2 \
  && cd Lmod-${LMOD_VER} \
@@ -17,6 +20,8 @@ RUN curl -LO https://sourceforge.net/projects/lmod/files/Lmod-${LMOD_VER}.tar.bz
  && cd .. \
  && rm -rf Lmod-${LMOD_VER} \
  && rm -rf Lmod-${LMOD_VER}.tar.bz2 \
+ && rm -f /etc/profile.d/modules.sh \
+ && rm -f /etc/profile.d/modules.csh \
  && ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/modules.sh \
  && ln -s /opt/apps/lmod/lmod/init/cshrc /etc/profile.d/modules.csh
 # install requirements to build OpenSSL 1.1 and 3.0 from source


### PR DESCRIPTION
This MR adds a fix for the containers `almalinux-9.0` and `centosstream-9`

- add `--allowerasing` to allow to install `curl` and remove conflicting `curl-minimal` which is part of the base image. The installed `curl-minimal` caused a problem on `arm64` when `dnf` tried to install `curl`.

and a fix for `centosstream-9`:

- the packages `gcc-c++` has a dependency on `environment-modules`, but we want to use Lmod. Therefore we need to remove `/etc/profile.d/modules.{sh,csh}` to be able to build Lmod from source and use it.

