### PR TITLE
One step multi-platform action

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -62,9 +62,13 @@ jobs:
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3
         with:
-          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}
+          tags: |
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}:latest
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}:${{ env.IMAGE_TAG }}
           context: ${{ matrix.tag }}
-          platforms: linux/amd64,linux/arm64
+          platforms: |
+            linux/amd64
+            linux/arm64
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Convert and store repository owner in lowercase
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
-          echo IMAGE_TAG=$(date +"%F")-{{ github.GITHUB_RUN_ID }} >> $GITHUB_ENV
+          echo IMAGE_TAG=$(date +"%F")-${{ github.GITHUB_RUN_ID }} >> $GITHUB_ENV
 
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
           echo IMAGE_TAG=$(date +"%F")-${{ github.run_id }}.${{ github.run_number }} >> $GITHUB_ENV
-
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3
         with:
@@ -72,8 +71,29 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
-
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Build and push to amd64
+        uses: docker/build-push-action@v3
+        with:
+          tags: |
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-amd64:latest
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-amd64:${{ env.IMAGE_TAG }}
+          context: ${{ matrix.tag }}
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+      - name: Build and push to arm64
+        uses: docker/build-push-action@v3
+        with:
+          tags: |
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-arm64:latest
+            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-arm64:${{ env.IMAGE_TAG }}
+          context: ${{ matrix.tag }}
+          platforms: linux/arm64
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Convert and store repository owner in lowercase
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
-          echo IMAGE_TAG=$(date +"%F")-${{ github.GITHUB_RUN_ID }} >> $GITHUB_ENV
+          echo IMAGE_TAG=$(date +"%F")-${{ github.run_id }}.${{ github.run_number }} >> $GITHUB_ENV
 
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -9,7 +9,6 @@ jobs:
       contents: read
     strategy:
       matrix:
-        platform: [amd64, arm64]
         tag:
           - centos-7.9-python3
           - centos-7.9
@@ -59,13 +58,14 @@ jobs:
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
           echo DOCKERFILE=${{ matrix.tag }}/Dockerfile >> $GITHUB_ENV
+          echo IMAGE_TAG=$(date +"%F")-{{ github.GITHUB_RUN_ID }} >> $GITHUB_ENV
 
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3
         with:
-          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-${{ matrix.platform }}
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}:{{ env.IMAGE_TAG }}
           file: ${{ env.DOCKERFILE }}
-          platforms: linux/${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -74,55 +74,3 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  docker_manifest:
-    name: Docker manifest
-    needs: build_publish
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    strategy:
-      matrix:
-        tag:
-          - centos-7.9-python3
-          - centos-7.9
-          - centos-8.5
-          - centosstream-9
-          - fedora-35
-          - fedora-36
-          - opensuse-15.3
-          - opensuse-15.4
-          - rockylinux-8.5
-          - rockylinux-8.6
-          - rockylinux-8.7
-          - rockylinux-9.0
-          - rockylinux-9.1
-          - almalinux-8.6
-          - almalinux-9.0
-          - ubuntu-20.04
-          - ubuntu-22.04
-    steps:
-      - name: Login to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Convert and store repository owner in lowercase
-        run: |
-          echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
-
-      - name: Run docker manifest
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        run: |
-          docker manifest create \
-            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }} \
-            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-amd64 \
-            ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}-arm64
-
-      - name: Push manifest
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        run: docker manifest push ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -57,14 +57,13 @@ jobs:
       - name: Convert and store repository owner in lowercase
         run: |
           echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
-          echo DOCKERFILE=${{ matrix.tag }}/Dockerfile >> $GITHUB_ENV
           echo IMAGE_TAG=$(date +"%F")-{{ github.GITHUB_RUN_ID }} >> $GITHUB_ENV
 
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3
         with:
           tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}:{{ env.IMAGE_TAG }}
-          file: ${{ env.DOCKERFILE }}
+          context: ${{ matrix.tag }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build and push to GitHub Packages
         uses: docker/build-push-action@v3
         with:
-          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}:{{ env.IMAGE_TAG }}
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/${{ matrix.tag }}
           context: ${{ matrix.tag }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}


### PR DESCRIPTION
I am not a github workflow expert, but judging from the `docker buildx` command you are able to run a multi-arch build and push have `docker buildx` create a manifest-list directly ([source](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/)).
![Screenshot 2023-01-22 at 12 01 31](https://user-images.githubusercontent.com/1420201/213912460-690099c4-b949-4c5e-87a3-d24fa0ba72ee.png)
