### PR TITLE
add `sudo` to all containers, so it can be used to run commands with non-root user via 'sudo -u easybuild ...'

### DIFF
--- a/almalinux-8.6/Dockerfile
+++ b/almalinux-8.6/Dockerfile
@@ -4,5 +4,5 @@ RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/almalinux-9.0/Dockerfile
+++ b/almalinux-9.0/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update \
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
 # --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
-RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source

--- a/centos-7.9-python3/Dockerfile
+++ b/centos-7.9-python3/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7.9.2009
 RUN useradd -ms /bin/bash easybuild
 RUN yum -y install epel-release && yum -y install python3 python3-pip Lmod
-RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN yum -y update ca-certificates
 RUN python3 -m pip install archspec

--- a/centos-7.9/Dockerfile
+++ b/centos-7.9/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7.9.2009
 RUN useradd -ms /bin/bash easybuild
 RUN yum -y install epel-release && yum -y install python python2-pip Lmod
-RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN yum -y update ca-certificates
 # In order to install archspec we need to upgrade pip to latest version for Python 2
 RUN python -m pip install --upgrade 'pip<21' && python -m pip install archspec

--- a/centos-8.5/Dockerfile
+++ b/centos-8.5/Dockerfile
@@ -10,5 +10,5 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
 # enable PowerTools repository, required by Lmod in EPEL
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
-RUN dnf -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/centosstream-9/Dockerfile
+++ b/centosstream-9/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update \
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
 # --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
-RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y --allowerasing install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -2,5 +2,5 @@ FROM fedora:35
 RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install python3 python3-pip Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -2,5 +2,5 @@ FROM fedora:36
 RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install python3 python3-pip Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/opensuse-15.3/Dockerfile
+++ b/opensuse-15.3/Dockerfile
@@ -2,5 +2,5 @@ FROM opensuse/leap:15.3
 RUN useradd -ms /bin/bash easybuild
 RUN zypper --non-interactive install python3 python3-pip lua-lmod
 # glibc-locale provides locale stuff, required for example by libxml2 test suite
-RUN zypper --non-interactive install bzip2 curl diffutils file gcc-c++ git glibc-locale gzip openssl libopenssl-devel make rdma-core-devel patch tar timezone unzip which xz
+RUN zypper --non-interactive install bzip2 curl diffutils file gcc-c++ git glibc-locale gzip openssl libopenssl-devel make rdma-core-devel patch sudo tar timezone unzip which xz
 RUN python3 -m pip install archspec

--- a/opensuse-15.4/Dockerfile
+++ b/opensuse-15.4/Dockerfile
@@ -2,5 +2,5 @@ FROM opensuse/leap:15.4
 RUN useradd -ms /bin/bash easybuild
 RUN zypper --non-interactive install python3 python3-pip lua-lmod
 # glibc-locale provides locale stuff, required for example by libxml2 test suite
-RUN zypper --non-interactive install bzip2 curl diffutils file gcc-c++ git glibc-locale gzip openssl libopenssl-devel make rdma-core-devel patch tar timezone unzip which xz
+RUN zypper --non-interactive install bzip2 curl diffutils file gcc-c++ git glibc-locale gzip openssl libopenssl-devel make rdma-core-devel patch sudo tar timezone unzip which xz
 RUN python3 -m pip install archspec

--- a/rockylinux-8.5/Dockerfile
+++ b/rockylinux-8.5/Dockerfile
@@ -4,5 +4,5 @@ RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/rockylinux-8.6/Dockerfile
+++ b/rockylinux-8.6/Dockerfile
@@ -4,5 +4,5 @@ RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/rockylinux-8.7/Dockerfile
+++ b/rockylinux-8.7/Dockerfile
@@ -4,5 +4,5 @@ RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN python3 -m pip install archspec

--- a/rockylinux-9.0/Dockerfile
+++ b/rockylinux-9.0/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update \
 && dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source

--- a/rockylinux-9.1/Dockerfile
+++ b/rockylinux-9.1/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf -y update \
 && dnf -y install epel-release && dnf -y install python3 python3-pip
 # --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch tar unzip which xz
+RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build Lmod
 RUN dnf -y install procps-ng lua-filesystem lua-posix lua-devel lua tcl
 # Build Lmod from source

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -7,5 +7,5 @@ RUN apt update \
 && curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb \
 && apt install -y ./lmod_${LMOD_VERSION}_all.deb
 # debianutils provides 'which' command
-RUN apt install -y bzip2 debianutils diffutils file gcc g++ git gzip libibverbs-dev openssl libssl-dev make patch tar unzip xz-utils
+RUN apt install -y bzip2 debianutils diffutils file gcc g++ git gzip libibverbs-dev openssl libssl-dev make patch sudo tar unzip xz-utils
 RUN python3 -m pip install archspec

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -7,5 +7,5 @@ RUN apt update \
 && curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb \
 && apt install -y ./lmod_${LMOD_VERSION}_all.deb
 # debianutils provides 'which' command
-RUN apt install -y bzip2 debianutils diffutils file gcc g++ git gzip libibverbs-dev openssl libssl-dev make patch tar unzip xz-utils
+RUN apt install -y bzip2 debianutils diffutils file gcc g++ git gzip libibverbs-dev openssl libssl-dev make patch sudo tar unzip xz-utils
 RUN python3 -m pip install archspec


### PR DESCRIPTION
Somewhat required because launching container with `--user easybuild` isn't working at all, cfr. https://github.com/actions/checkout/issues/1014