### PR TITLE
add recipe for Ubuntu 20.04 container with Python 2.7

### DIFF
--- a/.github/workflows/build-publish-containers.yml
+++ b/.github/workflows/build-publish-containers.yml
@@ -28,6 +28,7 @@ jobs:
           - almalinux-8.6
           - almalinux-9.0
           - ubuntu-20.04
+          - ubuntu-20.04-python2
           - ubuntu-22.04
       fail-fast: false
     steps:

--- a/ubuntu-20.04-python2/Dockerfile
+++ b/ubuntu-20.04-python2/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04
+RUN useradd -ms /bin/bash easybuild
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update \
+&& apt install -y curl python2 python-pip-whl \
+&& LMOD_VERSION=8.6.12 \
+&& curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb \
+&& apt install -y ./lmod_${LMOD_VERSION}_all.deb
+# debianutils provides 'which' command
+RUN apt install -y bzip2 debianutils diffutils file gcc g++ git gzip libibverbs-dev openssl libssl-dev make patch sudo tar unzip xz-utils
+RUN python2 -m pip install archspec==0.1.4

--- a/ubuntu-20.04-python2/Dockerfile
+++ b/ubuntu-20.04-python2/Dockerfile
@@ -3,6 +3,8 @@ RUN useradd -ms /bin/bash easybuild
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \
 && apt install -y curl python2 python-pip-whl \
+&& curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
+&& python2 get-pip.py \
 && LMOD_VERSION=8.6.12 \
 && curl -OL https://github.com/surak/Lmod/releases/download/${LMOD_VERSION}/lmod_${LMOD_VERSION}_all.deb \
 && apt install -y ./lmod_${LMOD_VERSION}_all.deb


### PR DESCRIPTION
Running the EasyBuild framework tests in a CentOS 7.9 container with Python 2.7 is proving to be quite messy in https://github.com/easybuilders/easybuild-framework/pull/4333, I think it will be less painful with Ubuntu 20.04...