### PR TITLE
add perl-Thread-Queue to Rocky Linux 8.8 container

### DIFF
--- a/rockylinux-8.8/Dockerfile
+++ b/rockylinux-8.8/Dockerfile
@@ -4,5 +4,6 @@ RUN useradd -ms /bin/bash easybuild
 RUN dnf -y install dnf-plugins-core && dnf config-manager --set-enabled powertools \
 && dnf -y install epel-release && dnf -y install python3 Lmod
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
+# perl-Thread-Queue is required by Automake
+RUN dnf -y install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel patch perl-Thread-Queue rdma-core-devel sudo tar unzip which xz
 RUN python3 -m pip install archspec


### PR DESCRIPTION
required by `Automake/1.16.5`, which is required for `Autotools/20220317`