### PR TITLE
Install a node 20 built against GLibc 2.17 for Centos 7.9

### DIFF
--- a/centos-7.9-python3/Dockerfile
+++ b/centos-7.9-python3/Dockerfile
@@ -8,3 +8,5 @@ RUN yum -y install epel-release && yum -y install python3 python3-pip Lmod
 RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 RUN yum -y update ca-certificates
 RUN python3 -m pip install archspec
+# Usable Node 20 required for GitHub actions. The one from GitHub doesn't work with this containers GLibc
+curl -sL https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz | tar -xJ --strip-components 1 -C /node20217

--- a/centos-7.9/Dockerfile
+++ b/centos-7.9/Dockerfile
@@ -9,3 +9,5 @@ RUN yum -y install bzip2 curl diffutils file gcc-c++ git gzip make openssl opens
 RUN yum -y update ca-certificates
 # In order to install archspec we need to upgrade pip to latest version for Python 2
 RUN python -m pip install --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade 'pip<21' && python -m pip install archspec
+# Usable Node 20 required for GitHub actions. The one from GitHub doesn't work with this containers GLibc
+RUN curl -sL https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz | tar -xJ --strip-components 1 -C /node20217


### PR DESCRIPTION
See https://github.com/actions/checkout/issues/1590

The folder can then be mounted over the location that GitHub Actions would use. This just allows downloading the file in each CI run