### PR TITLE
add glibc-gconv-extra to Rocky Linux 9 + 10 containers

### DIFF
--- a/rockylinux-10.1/Dockerfile
+++ b/rockylinux-10.1/Dockerfile
@@ -6,7 +6,8 @@ RUN dnf -y update \
 && dnf -y install epel-release && dnf -y install python3 python3-pip Lmod
 # --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
+# glibc-gconv-extra provides support for ISO-8859-5 encoding (required by libxml2 tests)
+RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-gconv-extra glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build OpenSSL 1.1 and 3.0 from source
 RUN dnf -y install perl-FindBin perl-File-Compare perl-File-Copy perl-IPC-Cmd perl-Pod-Html
 RUN python3 -m pip install archspec

--- a/rockylinux-9.5/Dockerfile
+++ b/rockylinux-9.5/Dockerfile
@@ -6,7 +6,8 @@ RUN dnf -y update \
 && dnf -y install epel-release && dnf -y install python3 python3-pip Lmod
 # --allowerasing is required to allow to install curl and remove conflicting curl-minimal which is part of the base image
 # glibc-langpack-en provides locale stuff (for en_US.UTF-8)
-RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
+# glibc-gconv-extra provides support for ISO-8859-5 encoding (required by libxml2 tests)
+RUN dnf -y --allowerasing install bzip2 curl diffutils file findutils gcc-c++ git glibc-gconv-extra glibc-langpack-en gzip make openssl openssl-devel rdma-core-devel patch sudo tar unzip which xz
 # install requirements to build OpenSSL 1.1 and 3.0 from source
 RUN dnf -y install perl-FindBin perl-File-Compare perl-File-Copy perl-IPC-Cmd perl-Pod-Html
 RUN python3 -m pip install archspec


### PR DESCRIPTION
Required for `libxml2` tests, popped up when trying to install `libxml2-2.14.3-GCCcore-14.3.0.eb` in Rocky Linux 9 container:
```
./test/errors/759398.xml:1: parser error : Unsupported encoding: ISO-8859-5
<?xml version='1.0' encoding='ISO-8859-5' standalone='no'?>
                                         ^
./test/errors/759398.xml : failed to parse
```

No need to add to Rocky Linux 8 container, since it's already there (as a dependency for something else, probably):
```
$ apptainer shell docker://ghcr.io/easybuilders/rockylinux-8.10
Apptainer> rpm -qa | grep glibc-gconv
glibc-gconv-extra-2.28-251.el8_10.25.x86_64
```